### PR TITLE
Contractor => supplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ In the European Union, this extension's fields correspond to [eForms BG-711 (Con
       "hasElectronicOrdering": false,
       "electronicInvoicingPolicy": "required",
       "reservedExecution": true,
-      "performanceTerms": "A set of KPIs will be developed for this contract and the successful contractor will be measured against these for the duration of the contract. Please refer to briefing document for further details.",
+      "performanceTerms": "A set of KPIs will be developed for this contract and the successful supplier will be measured against these for the duration of the contract. Please refer to briefing document for further details.",
       "financialTerms": "In the event that a work referred to in § 2.6 of the Agreement is created as part of the implementation of the Subject Matter of the Agreement, the Contractor shall indicate on the invoice what proportion of the remuneration for implementation.",
       "tendererLegalForm": "Contractors may jointly apply for the contract.",
       "hasExclusiveRights": false,
       "operatorRevenueShare": 0.25,
-      "socialStandards": "The contractor maintains the social, collective bargaining and labor law obligations according to Union law, national law or collective agreements. 4 paragraph 4a Regulation 13707/2007."
+      "socialStandards": "The supplier maintains the social, collective bargaining and labor law obligations according to Union law, national law or collective agreements. 4 paragraph 4a Regulation 13707/2007."
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In the European Union, this extension's fields correspond to [eForms BG-711 (Con
       "hasElectronicOrdering": false,
       "electronicInvoicingPolicy": "required",
       "reservedExecution": true,
-      "performanceTerms": "A set of KPIs will be developed for this contract and the successful supplier will be measured against these for the duration of the contract. Please refer to briefing document for further details.",
+      "performanceTerms": "A set of KPIs will be developed for this contract and the successful tenderer will be measured against these for the duration of the contract. Please refer to briefing document for further details.",
       "financialTerms": "In the event that a work referred to in § 2.6 of the Agreement is created as part of the implementation of the Subject Matter of the Agreement, the Contractor shall indicate on the invoice what proportion of the remuneration for implementation.",
       "tendererLegalForm": "Contractors may jointly apply for the contract.",
       "hasExclusiveRights": false,

--- a/release-schema.json
+++ b/release-schema.json
@@ -97,7 +97,7 @@
         },
         "exclusiveRights": {
           "title": "Exclusive rights",
-          "description": "The nature and extent of the exclusive rights granted by the procuring entity to the contractor.",
+          "description": "The nature and extent of the exclusive rights granted by the procuring entity to the supplier.",
           "type": [
             "string",
             "null"
@@ -105,7 +105,7 @@
         },
         "operatorRevenueShare": {
           "title": "Operator revenue share",
-          "description": "The percentage of revenue from the sale of tickets allocated to the contractor.",
+          "description": "The percentage of revenue from the sale of tickets allocated to the supplier.",
           "type": [
             "number",
             "null"


### PR DESCRIPTION
This is the only extension in which I have found occurences of "contractor". I have checked those (`ls -1 ~/git/ocds_*`):

- ocds_awardCriteria_extension
- ocds_bid_extension
- ocds_bidOpening_extension
- ocds_communication_extension
- ocds_contractTerms_extension
- ocds_designContest_extension
- ocds_eu_extension
- ocds_options_extension
- ocds_organizationClassification_extension
- ocds_otherRequirements_extension
- ocds_procedure_extension
- ocds_procurementMethodRationaleClassifications_extension
- ocds_procurement_techniques_extension
- ocds_secondStageDescription_extension
- ocds_selectionCriteria_extension
- ocds_subcontracting_extension
- ocds_submissionTerms_extension
- ocds_unstructuredChanges_extension